### PR TITLE
Add Missing Dependence

### DIFF
--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -6,3 +6,4 @@ opencv-python>=4.2.0.32
 Pillow
 tornado
 imgaug==0.2.6
+ipython


### PR DESCRIPTION
## Fix the Missing Dependence bug

when i run bmf demo using DeOldfy, there is the error. there are more information in this [PR](https://github.com/BabitMF/bmf/pull/118)
```
root@73559b1846e1:~/bmf/bmf/demo/colorization_python# python3.8 deoldify_demo.py 
['./DeOldify', '/root/bmf/bmf/demo/colorization_python', '/root/bmf/bmf/demo/colorization_python', '/usr/local/lib/python3.8/dist-packages/nvcv_python', '/root/bmf/output', '/usr/lib/python38.zip', '/usr/lib/python3.8', '/usr/lib/python3.8/lib-dynload', '/usr/local/lib/python3.8/dist-packages', '/usr/lib/python3/dist-packages']
INFO:matplotlib.font_manager:generated new fontManager
generated new fontManager
INFO:numexpr.utils:Note: NumExpr detected 40 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
Note: NumExpr detected 40 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
INFO:numexpr.utils:NumExpr defaulting to 8 threads.
NumExpr defaulting to 8 threads.
Traceback (most recent call last):
  File "deoldify_demo.py", line 2, in <module>
    import py_deoldify_module
  File "/root/bmf/bmf/demo/colorization_python/py_deoldify_module.py", line 14, in <module>
    from deoldify.visualize import *
  File "/root/bmf/bmf/demo/colorization_python/./DeOldify/deoldify/visualize.py", line 13, in <module>
    from IPython import display as ipythondisplay
ModuleNotFoundError: No module named 'IPython'
```
so i add the package `ipython` into requirements